### PR TITLE
Ubuntu build fixes and instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ enable_testing()
 # where to find cmake modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
+
 # find boost headers and libs
 set(Boost_DEBUG TRUE)
 # in order to load libbackend.so into the jvm, we need to link against a shared
@@ -29,7 +31,7 @@ set(Boost_DEBUG TRUE)
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost REQUIRED COMPONENTS thread regex-mt)
+find_package(Boost REQUIRED COMPONENTS thread regex date_time)
 include_directories(${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 message(STATUS ${Boost_INCLUDE_DIRS})
@@ -136,7 +138,7 @@ add_subdirectory(common/thrift)
 add_subdirectory(be)
 
 # Run FE and BE tests
-add_custom_target(testall 
+add_custom_target(testall
   COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/fe mvn test
   COMMAND ${CMAKE_SOURCE_DIR}/bin/runbackendtests.sh
 )

--- a/README.md
+++ b/README.md
@@ -1,18 +1,36 @@
 # Cloudera Impala
 
-Cloudera Impala is a distributed query execution engine that runs against data stored natively in Apache HDFS and Apache HBase. This public repository is a snapshot of our internal development repository that will be updated periodically as we prepare new releases. 
+Cloudera Impala is a distributed query execution engine that runs against data stored natively in Apache HDFS and Apache HBase. This public repository is a snapshot of our internal development repository that will be updated periodically as we prepare new releases.
 
-The rest of this README describes how to build Cloudera Impala from this repository. Further documentation about Cloudera Impala can be found [here](https://ccp.cloudera.com/display/IMPALA10BETADOC/Cloudera+Impala+1.0+Beta+Documentation). 
+The rest of this README describes how to build Cloudera Impala from this repository. Further documentation about Cloudera Impala can be found [here](https://ccp.cloudera.com/display/IMPALA10BETADOC/Cloudera+Impala+1.0+Beta+Documentation).
 
-# Building Cloudera Impala on CentOS 6.2
+# Building Cloudera Impala
 
-## Prerequisites
-
-### Installing prerequisite packages
+## Prerequisites on CentOS 6.2
 
     sudo yum install boost-test boost-program-options libevent-devel automake libtool flex bison gcc-c++ openssl-devel \
     make cmake doxygen.x86_64 glib-devel boost-devel python-devel bzip2-devel svn libevent-devel cyrus-sasl-devel \
     wget git unzip
+
+### Install LLVM
+
+    wget http://llvm.org/releases/3.0/llvm-3.0.tar.gz
+    tar xvzf llvm-3.0.tar.gz
+    cd llvm-3.0.src/tools
+    svn co http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_30/final/ clang
+    cd ../projects
+    svn co http://llvm.org/svn/llvm-project/compiler-rt/tags/RELEASE_30/final/ compiler-rt
+    cd ..
+    ./configure --with-pic
+    make
+    sudo make install
+
+## Prerequisites on Ubuntu 12.04 and newer
+
+    sudo apt-get install unzip build-essential autoconf git libboost1.48-all-dev libevent-dev \
+                         libbz2-dev cmake llvm-3.0 clang doxygen
+
+## Other prerequisites
 
 ### Install Thrift 0.7.0
 
@@ -33,19 +51,6 @@ _Note: we will be upgrading to a more recent Thrift in the near future, but for 
     make
     sudo make install
 
-### Install LLVM
-
-    wget http://llvm.org/releases/3.0/llvm-3.0.tar.gz
-    tar xvzf llvm-3.0.tar.gz
-    cd llvm.3.0.src/tools
-    svn co http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_30/final/ clang
-    cd ../projects
-    svn co http://llvm.org/svn/llvm-project/compiler-rt/tags/RELEASE_30/final/ compiler-rt
-    cd ..
-    ./configure --with-pic
-    make
-    sudo make install
-
 ### Install the JDK
 
 Make sure that the Oracle Java Development Kit 6 is installed (not OpenJDK), and that `JAVA_HOME` is set in your environment.
@@ -53,13 +58,13 @@ Make sure that the Oracle Java Development Kit 6 is installed (not OpenJDK), and
 ### Install Maven
 
     wget http://www.fightrice.com/mirrors/apache/maven/maven-3/3.0.4/binaries/apache-maven-3.0.4-bin.tar.gz
-    tar xvf apache-maven-3.0.4.tar.gz && sudo mv apache-maven-3.0.4 /usr/local
-   
+    tar xvf apache-maven-3.0.4-bin.tar.gz && sudo mv apache-maven-3.0.4 /usr/local
+
 Add the following three lines to your .bashrc:
 
     export M2_HOME=/usr/local/apache-maven-3.0.4
-    export M2=$M2_HOME/bin  
-    export PATH=$M2:$PATH 
+    export M2=$M2_HOME/bin
+    export PATH=$M2:$PATH
 
 And make sure you pick up the changes either by logging in to a fresh shell or running:
 
@@ -80,13 +85,16 @@ and you should see at least:
     git clone https://github.com/cloudera/impala.git
 
 ### Set the Impala environment
-  
+
     cd impala
     . bin/impala-config.sh
 
 Confirm your environment looks correct:
 
-    (11:11:21@desktop) ~/src/cloudera/impala-public (master) $ env | grep "IMPALA.*VERSION"
+    env | grep "IMPALA.*VERSION"
+
+The output should be:
+
     IMPALA_CYRUS_SASL_VERSION=2.1.23
     IMPALA_HBASE_VERSION=0.92.1-cdh4.1.0
     IMPALA_SNAPPY_VERSION=1.0.5
@@ -106,8 +114,15 @@ Confirm your environment looks correct:
 
 ### Build Impala
 
+On CentOS:
+
     cd ${IMPALA_HOME}
     ./build_public.sh -build_thirdparty
+
+On Ubuntu:
+
+    cd ${IMPALA_HOME}
+    LLVM_VERSION=3.0 ./build_public.sh -build_thirdparty
 
 ## Wrapping up
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -28,7 +28,7 @@ PROJECT(ASSEMBLER)
 # compiler flags that are common across debug/release builds
 #  - msse4.2: Enable sse4.2 compiler intrinsics.
 #  - Wall: Enable all warnings.
-#  - Wno-sign-compare: suppress warnings for comparison between signed and unsigned 
+#  - Wno-sign-compare: suppress warnings for comparison between signed and unsigned
 #    integers
 #  - pthread: enable multithreaded malloc
 #  - DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG: enable nanosecond precision for boost
@@ -82,7 +82,7 @@ else()
 endif ()
 
 # Add flags that are common across build types
-#  - fverboase-asm creates better annotated assembly.  This doesn't seem to affect 
+#  - fverboase-asm creates better annotated assembly.  This doesn't seem to affect
 #    when building the binary.
 # LLMV_CFLAGS - Adding llvm compile flags
 SET(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
@@ -200,7 +200,7 @@ set (IMPALA_LINK_LIBS
   gflagsstatic
 #  tcmallocstatic  This crashes the FE tests.
   pprofstatic
-  -lz -lbz2 -lboost_date_time
+  -lz -lbz2
 )
 MESSAGE(STATUS, "${IMPALA_LINK_LIBS}")
 

--- a/be/src/runtime/coordinator.cc
+++ b/be/src/runtime/coordinator.cc
@@ -47,7 +47,6 @@
 #include "exec/scan-node.h"
 #include "util/debug-util.h"
 #include "util/hdfs-util.h"
-#include "util/container-util.h"
 #include "gen-cpp/ImpalaInternalService.h"
 #include "gen-cpp/ImpalaInternalService_types.h"
 #include "gen-cpp/Frontend_types.h"

--- a/be/src/runtime/coordinator.h
+++ b/be/src/runtime/coordinator.h
@@ -35,6 +35,7 @@
 #include "common/global-types.h"
 #include "util/progress-updater.h"
 #include "util/runtime-profile.h"
+#include "util/container-util.h"
 #include "runtime/runtime-state.h"
 #include "sparrow/simple-scheduler.h"
 #include "gen-cpp/Types_types.h"
@@ -110,7 +111,7 @@ class Coordinator {
   // the next GetNext() call. If *batch is NULL, execution has completed and GetNext()
   // must not be called again.
   // GetNext() will not set *batch=NULL until all backends have
-  // either completed or have failed. 
+  // either completed or have failed.
   // It is safe to call GetNext() even in the case where there is no coordinator fragment
   // (distributed INSERT).
   // '*batch' is owned by the underlying PlanFragmentExecutor and must not be deleted.
@@ -163,15 +164,15 @@ class Coordinator {
 
  private:
   class BackendExecState;
-    
+
   // Typedef for boost utility to compute averaged stats
   // TODO: including the median doesn't compile, looks like some includes are missing
-  typedef boost::accumulators::accumulator_set<int64_t, 
+  typedef boost::accumulators::accumulator_set<int64_t,
       boost::accumulators::features<
-      boost::accumulators::tag::min, 
-      boost::accumulators::tag::max, 
-      boost::accumulators::tag::mean, 
-      boost::accumulators::tag::variance> 
+      boost::accumulators::tag::min,
+      boost::accumulators::tag::max,
+      boost::accumulators::tag::mean,
+      boost::accumulators::tag::variance>
   > SummaryStats;
 
   ExecEnv* exec_env_;
@@ -193,7 +194,7 @@ class Coordinator {
     // Total finished scan ranges per node
     CounterMap scan_ranges_complete_counters;
   };
-  
+
   // execution parameters for a single fragment; used to assemble the
   // per-fragment instance TPlanFragmentExecParams;
   // hosts.size() == instance_ids.size()
@@ -207,6 +208,17 @@ class Coordinator {
     std::vector<TUniqueId> instance_ids;
     std::vector<TPlanFragmentDestination> destinations;
     std::map<PlanNodeId, int> per_exch_num_senders;
+
+    // to work around a bug in Boost 1.4x where the copy assignment operator
+    // for unordered_map doesn't use const for the argument
+    FragmentExecParams &operator=(const FragmentExecParams &src) {
+      hosts = src.hosts;
+      instance_ids = src.instance_ids;
+      destinations = src.destinations;
+      per_exch_num_senders = src.per_exch_num_senders;
+      data_server_map = src.data_server_map;
+      return *this;
+    }
   };
   // populated in ComputeFragmentExecParams()
   std::vector<FragmentExecParams> fragment_exec_params_;
@@ -219,7 +231,7 @@ class Coordinator {
   // vector is indexed by fragment index from TQueryExecRequest.fragments;
   // populated in ComputeScanRangeAssignment()
   std::vector<FragmentScanRangeAssignment> scan_range_assignment_;
-  
+
   // BackendExecStates owned by obj_pool()
   std::vector<BackendExecState*> backend_exec_states_;
 
@@ -261,7 +273,7 @@ class Coordinator {
 
   // True if execution has completed, false otherwise.
   bool execution_completed_;
-  
+
   // Number of remote fragments that have completed
   int num_remote_fragements_complete_;
 
@@ -321,7 +333,7 @@ class Coordinator {
 
     // Root profile for all fragment instances for this fragment
     RuntimeProfile* root_profile;
-    
+
     // Bytes assigned for instances of this fragment
     SummaryStats bytes_assigned;
 
@@ -336,7 +348,7 @@ class Coordinator {
   // This array is only modified at coordinator startup and query completion and
   // does not need locks.
   std::vector<PerFragmentProfileData> fragment_profiles_;
-    
+
   // Throughput counters for the coordinator fragment
   FragmentInstanceCounters coordinator_counters_;
 
@@ -401,8 +413,8 @@ class Coordinator {
   // Derived counter function: aggregates throughput for node_id across all backends
   // (id needs to be for a ScanNode)
   int64_t ComputeTotalThroughput(int node_id);
-  
-  // Derived counter function: aggregates total completed scan ranges for node_id 
+
+  // Derived counter function: aggregates total completed scan ranges for node_id
   // across all backends(id needs to be for a ScanNode)
   int64_t ComputeTotalScanRangesComplete(int node_id);
 

--- a/cmake_modules/FindLlvm.cmake
+++ b/cmake_modules/FindLlvm.cmake
@@ -7,9 +7,9 @@
 #  LLVM_MODULE_LIBS - list of llvm libs for working with modules.
 #  LLVM_FOUND       - True if llvm found.
 
-find_program(LLVM_CONFIG_EXECUTABLE llvm-config)
+find_program(LLVM_CONFIG_EXECUTABLE NAMES llvm-config llvm-config-$ENV{LLVM_VERSION})
 find_program(LLVM_CLANG_EXECUTABLE clang++)
-find_program(LLVM_OPT_EXECUTABLE opt)
+find_program(LLVM_OPT_EXECUTABLE NAMES opt opt-$ENV{LLVM_VERSION})
 
 if (NOT LLVM_CONFIG_EXECUTABLE)
   message(FATAL_ERROR "Could not find llvm-config")
@@ -48,7 +48,7 @@ execute_process(
 #  OUTPUT_VARIABLE LLVM_CFLAGS
 #  OUTPUT_STRIP_TRAILING_WHITESPACE
 #)
-set(LLVM_CFLAGS 
+set(LLVM_CFLAGS
   "-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS")
 
 execute_process(
@@ -58,7 +58,7 @@ execute_process(
 )
 
 # Get the link libs we need.  llvm has many and we don't want to link all of the libs
-# if we don't need them.   
+# if we don't need them.
 execute_process(
   COMMAND ${LLVM_CONFIG_EXECUTABLE} --libnames core jit native ipo bitreader
   OUTPUT_VARIABLE LLVM_MODULE_LIBS

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -481,6 +481,9 @@
       <id>cdh.rcs.releases.repo</id>
       <url>https://repository.cloudera.com/content/groups/cdh-releases-rcs</url>
       <name>CDH Releases Repository</name>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -489,6 +492,9 @@
       <id>cdh.releases.repo</id>
       <url>https://repository.cloudera.com/content/repositories/releases</url>
       <name>CDH Releases Repository</name>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -497,6 +503,9 @@
       <id>cdh.snapshots.repo</id>
       <url>https://repository.cloudera.com/content/repositories/snapshots</url>
       <name>CDH Snapshots Repository</name>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -505,6 +514,9 @@
       <id>cloudera.thirdparty.repo</id>
       <url>https://repository.cloudera.com/content/repositories/third-party</url>
       <name>Cloudera Third Party Repository</name>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -516,6 +528,9 @@
       <id>cloudera.thirdparty.repo</id>
       <url>https://repository.cloudera.com/content/repositories/third-party</url>
       <name>Cloudera Third Party Repository</name>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -524,6 +539,9 @@
       <id>cloudera.snapshot.repo</id>
       <url>https://repository.cloudera.com/content/repositories/snapshots</url>
       <name>Cloudera Snapshot Repository</name>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
This pull request makes Impala build on Ubuntu 12.04. It basically contains these changes:
- Fix the linker settings to use `--no-as-needed` for executables (`--as-needed` is default on current Ubuntu distributions).
- Fix boost linking setup.
- Add an explicit copy assignment operator to `FragmentExecParams` to work around a bug with Boost 1.4x and newer compilers where Boost generates a copy assignment operator that takes a non-const argument, but newer compilers/STL require a const argument.
- Add support for versioned llvm binaries (e.g. `llvm-config-3.0`) as llvm ubuntu/debian packages don't (currently) use the alternatives system for these.
- Fix the maven repository settings (#8).
