### PR TITLE
Add sha1 checking to downloaded dependencies

### DIFF
--- a/thirdparty/download_thirdparty.sh
+++ b/thirdparty/download_thirdparty.sh
@@ -20,58 +20,63 @@ if [ "x${IMPALA_HOME}" = "x" ]; then
   exit 1;
 fi
 
+SIGNATURES=${IMPALA_HOME}/thirdparty/signatures.txt
+
+fetch() {
+    echo "Fetching $1"
+    filename=${2##*/}
+    wget "$2"
+    sha1sum=$(sha1sum "$filename")
+    if ! grep -qF "$sha1sum" "$SIGNATURES"; then
+        expected=$(grep "$filename" "$SIGNATURES")
+        echo "WARNING: Invalid sha1sum: $sha1sum. Expected: $expected"
+        echo "ABORTING"
+        exit 1
+    fi
+}
+
 cd ${IMPALA_HOME}/thirdparty
 
 echo "Removing everything in ${IMPALA_HOME}/thirdparty"
 git clean -xdf
 
-echo "Fetching gtest"
-wget http://googletest.googlecode.com/files/gtest-${IMPALA_GTEST_VERSION}.zip
+fetch gtest http://googletest.googlecode.com/files/gtest-${IMPALA_GTEST_VERSION}.zip
 unzip gtest-${IMPALA_GTEST_VERSION}.zip
 rm gtest-${IMPALA_GTEST_VERSION}.zip
 
-echo "Fetching glog"
-wget http://google-glog.googlecode.com/files/glog-${IMPALA_GLOG_VERSION}.tar.gz
+fetch glog http://google-glog.googlecode.com/files/glog-${IMPALA_GLOG_VERSION}.tar.gz
 tar xzf glog-${IMPALA_GLOG_VERSION}.tar.gz
 rm glog-${IMPALA_GLOG_VERSION}.tar.gz
 
-echo "Fetching gflags"
-wget http://gflags.googlecode.com/files/gflags-${IMPALA_GFLAGS_VERSION}.zip
+fetch gflags http://gflags.googlecode.com/files/gflags-${IMPALA_GFLAGS_VERSION}.zip
 unzip gflags-${IMPALA_GFLAGS_VERSION}.zip
 rm gflags-${IMPALA_GFLAGS_VERSION}.zip
 
-echo "Fetching gperftools"
-wget http://gperftools.googlecode.com/files/gperftools-${IMPALA_GPERFTOOLS_VERSION}.tar.gz
+fetch gperftools http://gperftools.googlecode.com/files/gperftools-${IMPALA_GPERFTOOLS_VERSION}.tar.gz
 tar xzf gperftools-${IMPALA_GPERFTOOLS_VERSION}.tar.gz
 rm gperftools-${IMPALA_GPERFTOOLS_VERSION}.tar.gz
 
-echo "Fetching snappy"
-wget http://snappy.googlecode.com/files/snappy-${IMPALA_SNAPPY_VERSION}.tar.gz
+fetch snappy http://snappy.googlecode.com/files/snappy-${IMPALA_SNAPPY_VERSION}.tar.gz
 tar xzf snappy-${IMPALA_SNAPPY_VERSION}.tar.gz
 rm snappy-${IMPALA_SNAPPY_VERSION}.tar.gz
 
-echo "Fetching cyrus-sasl"
-wget ftp://ftp.andrew.cmu.edu/pub/cyrus-mail/cyrus-sasl-${IMPALA_CYRUS_SASL_VERSION}.tar.gz
+fetch cyrus-sasl ftp://ftp.andrew.cmu.edu/pub/cyrus-mail/cyrus-sasl-${IMPALA_CYRUS_SASL_VERSION}.tar.gz
 tar xzf cyrus-sasl-${IMPALA_CYRUS_SASL_VERSION}.tar.gz
 rm cyrus-sasl-${IMPALA_CYRUS_SASL_VERSION}.tar.gz
 
-echo "Fetching mongoose"
-wget http://mongoose.googlecode.com/files/mongoose-${IMPALA_MONGOOSE_VERSION}.tgz
+fetch mongoose http://mongoose.googlecode.com/files/mongoose-${IMPALA_MONGOOSE_VERSION}.tgz
 tar xzf mongoose-${IMPALA_MONGOOSE_VERSION}.tgz
 rm mongoose-${IMPALA_MONGOOSE_VERSION}.tgz
 
-echo "Fetching Apache Hadoop"
-wget http://archive.cloudera.com/cdh4/cdh/4/hadoop-${IMPALA_HADOOP_VERSION}.tar.gz
+fetch "Apache Hadoop" http://archive.cloudera.com/cdh4/cdh/4/hadoop-${IMPALA_HADOOP_VERSION}.tar.gz
 tar xzf hadoop-${IMPALA_HADOOP_VERSION}.tar.gz
 rm hadoop-${IMPALA_HADOOP_VERSION}.tar.gz
 
-echo "Fetching Apache Hive"
-wget http://archive.cloudera.com/cdh4/cdh/4/hive-${IMPALA_HIVE_VERSION}.tar.gz
+fetch "Apache Hive" http://archive.cloudera.com/cdh4/cdh/4/hive-${IMPALA_HIVE_VERSION}.tar.gz
 tar xzf hive-${IMPALA_HIVE_VERSION}.tar.gz
 rm hive-${IMPALA_HIVE_VERSION}.tar.gz
 
-echo "Fetching Apache Thrift"
-wget http://archive.apache.org/dist/thrift/${IMPALA_THRIFT_VERSION}/thrift-${IMPALA_THRIFT_VERSION}.tar.gz
+fetch "Apache Thrift" http://archive.apache.org/dist/thrift/${IMPALA_THRIFT_VERSION}/thrift-${IMPALA_THRIFT_VERSION}.tar.gz
 tar xzf thrift-${IMPALA_THRIFT_VERSION}.tar.gz
 mkdir python-thrift-${IMPALA_THRIFT_VERSION}
 mv thrift-${IMPALA_THRIFT_VERSION}/lib/py/src python-thrift-${IMPALA_THRIFT_VERSION}/thrift

--- a/thirdparty/refresh_checksums.sh
+++ b/thirdparty/refresh_checksums.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+if [ "x${IMPALA_HOME}" = "x" ]; then
+  echo "IMPALA_HOME must be set"
+  exit 1;
+fi
+
+SIGNATURES=${IMPALA_HOME}/thirdparty/signatures.txt
+TMPDIR=${IMPALA_HOME}/thirdparty/tmp
+
+echo "Initializing temporary directory $TMPDIR"
+rm -rf "$TMPDIR"
+mkdir "$TMPDIR"
+cd "$TMPDIR"
+
+echo "Clearing $SIGNATURES"
+rm -f $SIGNATURES
+
+function get_checksum() {
+    echo "Checksumming $1"
+    filename=${2##*/}
+    wget "$2"
+    sha1sum "$filename" >> "$SIGNATURES"
+}
+
+get_checksum gtest http://googletest.googlecode.com/files/gtest-${IMPALA_GTEST_VERSION}.zip
+get_checksum glog http://google-glog.googlecode.com/files/glog-${IMPALA_GLOG_VERSION}.tar.gz
+get_checksum gflags http://gflags.googlecode.com/files/gflags-${IMPALA_GFLAGS_VERSION}.zip
+get_checksum gperftools http://gperftools.googlecode.com/files/gperftools-${IMPALA_GPERFTOOLS_VERSION}.tar.gz
+get_checksum snappy http://snappy.googlecode.com/files/snappy-${IMPALA_SNAPPY_VERSION}.tar.gz
+get_checksum cyrus-sasl ftp://ftp.andrew.cmu.edu/pub/cyrus-mail/cyrus-sasl-${IMPALA_CYRUS_SASL_VERSION}.tar.gz
+get_checksum mongoose http://mongoose.googlecode.com/files/mongoose-${IMPALA_MONGOOSE_VERSION}.tgz
+get_checksum "Apache Hadoop" http://archive.cloudera.com/cdh4/cdh/4/hadoop-${IMPALA_HADOOP_VERSION}.tar.gz
+get_checksum "Apache Hive" http://archive.cloudera.com/cdh4/cdh/4/hive-${IMPALA_HIVE_VERSION}.tar.gz
+get_checksum "Apache Thrift" http://archive.apache.org/dist/thrift/${IMPALA_THRIFT_VERSION}/thrift-${IMPALA_THRIFT_VERSION}.tar.gz
+
+echo "Removing $TMPDIR"
+rm -rf "$TMPDIR"

--- a/thirdparty/signatures.txt
+++ b/thirdparty/signatures.txt
@@ -1,0 +1,10 @@
+00d6be170eb9fc3b2198ffdcb1f1d6ba7fc6e621  gtest-1.6.0.zip
+94e641e50afd03c574af6a55084e94a347c911d7  glog-0.3.2.tar.gz
+1718dd556367ecdaa5f2ec7f83db04ebaa37449f  gflags-2.0.zip
+da7181a7ba9b5ee7302daf6c16e886c179fe8d1b  gperftools-2.0.tar.gz
+3a3df859cf33f78f8e945c3f67f28685f0f38bb1  snappy-1.0.5.tar.gz
+5df33a6788d6cd8329b109eff777c6cfae1a21bd  cyrus-sasl-2.1.23.tar.gz
+37854a7edacc8cef7e52ba3e0b3dbdcd7ec7d043  mongoose-3.3.tgz
+115086eca432d75a12779841aceb6d245fd65ad5  hadoop-2.0.0-cdh4.1.0.tar.gz
+0fb19cc97081ca3d32086ce051505b06b06fb639  hive-0.9.0-cdh4.1.0.tar.gz
+b8f6877bc75878984355da4efe171ad99ff05b6a  thrift-0.7.0.tar.gz


### PR DESCRIPTION
In the absence of code signing, sha1 checking is the next best thing.
