### PR TITLE
Fix default database selection on shell start

### DIFF
--- a/shell/impala_shell.py
+++ b/shell/impala_shell.py
@@ -361,7 +361,7 @@ class ImpalaShell(cmd.Cmd):
       if self.refresh_after_connect:
         self.cmdqueue.append('refresh')
       if self.default_db:
-        self.cmdqueue.append('use %s' % self.default_db)
+        self.cmdqueue.append('use %s%s' % (self.default_db, ImpalaShell.CMD_DELIM))
       self.__build_default_query_options_dict()
     self.last_query_handle = None
     # In the case that we lost connection while a command was being entered,


### PR DESCRIPTION
"use [database]" doesn't end with a semicolon, so the shell begins in a state with the command entered but not executed.
