### PR TITLE
Update impala_shell.py

### DIFF
--- a/shell/impala_shell.py
+++ b/shell/impala_shell.py
@@ -572,7 +572,7 @@ class ImpalaShell(cmd.Cmd):
     """Create a beeswax query object from a query string"""
     query = BeeswaxService.Query()
     query.hadoop_user = self.user
-    query.query = query_str
+    query.query = query_str.encode("utf_8")   """support Chinese"""
     query.configuration = self.__options_to_string_list()
     return query
 


### PR DESCRIPTION
impala shell exec statement with UTF-8 characters will fail,

create beeswax query encode query with utf-8 fix this problem.
