### PR TITLE
Remove unresolved parent in cdh4-extras pom.xml

### DIFF
--- a/thirdparty/cdh4-extras/pom.xml
+++ b/thirdparty/cdh4-extras/pom.xml
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>2.3</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>

--- a/thirdparty/cdh4-extras/pom.xml
+++ b/thirdparty/cdh4-extras/pom.xml
@@ -20,11 +20,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.cloudera</groupId>
-    <artifactId>parent</artifactId>
-    <version>1.0</version>
-  </parent>
   <groupId>com.cloudera.impala</groupId>
   <artifactId>cdh4-extras</artifactId>
   <version>0.1-SNAPSHOT</version>
@@ -65,6 +60,20 @@
       </snapshots>
     </repository>
   </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
- Remove the unresolved parent element in the pom.xml for thirdparty/cdh4-extras
- Add configuration to specify source version because Maven 3 on Java 1.7 complains and assumes an older source version (1.3) for some reason. 

Tracked by the following JIRA: https://issues.cloudera.org/browse/IMPALA-982
