### PR TITLE
Update impala_shell.py

### DIFF
--- a/shell/impala_shell.py
+++ b/shell/impala_shell.py
@@ -993,7 +993,7 @@ class ImpalaShell(object, cmd.Cmd):
 
         data = ""
         if self.print_progress and progress.total_scan_ranges > 0:
-          val = ((summary.progress.num_completed_scan_ranges * 100) /
+          val = int((summary.progress.num_completed_scan_ranges * 100) /
                  summary.progress.total_scan_ranges)
           fragment_text = "[%s%s] %s%%\n" % ("#" * val, " " * (100 - val), val)
           data += fragment_text


### PR DESCRIPTION
Fix a bug of printing progress bar.

`val`  may be a float value, and in this case an exception occurs from `"#*val`  of the next line.